### PR TITLE
Allow to override port using tikuiconfig port field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tikui/core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tikui/core",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@fontsource/montserrat": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tikui/core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Tikui core",
   "main": "src/tikui.js",
   "scripts": {

--- a/src/express.ts
+++ b/src/express.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import cors from 'cors';
 import { onLibResources } from './lib-resources';
 import * as options from './options.dev';
-import { project, projectSrc } from './tikui-loader';
+import { port, project, projectSrc } from './tikui-loader';
 import { onDocResources, sassRender } from './doc-resources';
 import { onExposedResources } from './exposed-resources';
 import { renderPugFile } from './pug-util';
@@ -18,7 +18,7 @@ const cacheDir: string = path.resolve(project, 'cache');
 
 app.use(cors());
 
-// Set views to sources files
+// Set views to source files
 app.set('views', projectSrc);
 
 // Create path
@@ -97,7 +97,7 @@ onExposedResources((absoluteFrom, relativeTo) => app.use(
 ));
 
 // Create server
-app.listen(3000, () => console.log('Styles are available at http://localhost:3000/'));
+app.listen(port, () => console.log(`Styles are available at http://localhost:${port}/`));
 
 // Watch on pug and css files
 reload(app).then((reloadReturned: any) => {

--- a/src/tikui-loader.ts
+++ b/src/tikui-loader.ts
@@ -9,12 +9,16 @@ interface TikuiConfig {
   src?: string;
   dist?: string;
   expose?: ExposedResources;
+  port?: number;
 }
 
 export const config: TikuiConfig = require(path.resolve(project, 'tikuiconfig.json'));
 
-const distDir = config.dist === undefined ? 'dist' : config.dist;
-const srcDir = config.src === undefined ? 'src' : config.src;
+const optionalOr = <T>(value: T | undefined, defaultValue: T): T => value === undefined ? defaultValue : value;
+
+const distDir = optionalOr(config.dist, 'dist');
+const srcDir = optionalOr(config.src, 'src');
 
 export const projectSrc = path.resolve(project, srcDir);
 export const projectDist = path.resolve(project, distDir);
+export const port = optionalOr(config.port, 3000);


### PR DESCRIPTION
To change the port (example with `8080`), please edit a tikuiconfig.json in a tikui project and add port field:

```json
{
  // […]
  "port": 8080
}
```