### PR TITLE
chore(deps): remove redundant @types dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,14 +31,12 @@
         "tikui-core": "dist/tikui-core.js"
       },
       "devDependencies": {
-        "@types/concurrently": "7.0.0",
         "@types/cors": "2.8.17",
         "@types/escape-html": "1.0.4",
         "@types/express": "4.17.21",
         "@types/jest": "29.5.12",
         "@types/node": "18.19.33",
         "@types/pug": "2.0.10",
-        "@types/sass": "1.45.0",
         "@types/showdown": "2.0.6",
         "@types/through2": "2.0.41",
         "cypress": "13.11.0",
@@ -1329,16 +1327,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/concurrently": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/concurrently/-/concurrently-7.0.0.tgz",
-      "integrity": "sha512-pUOv0XBVexkfVOLWwzh8CMK7b+dnXGvq+/sJKfcws6b0vuMqNw8UeZUiaO9mWxfyS0eYGQyxg+J9EpVRxUCunA==",
-      "deprecated": "This is a stub types definition. concurrently provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "concurrently": "*"
-      }
-    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -1462,16 +1450,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/sass": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-      "deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "sass": "*"
-      }
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -8377,15 +8355,6 @@
         "@types/node": "*"
       }
     },
-    "@types/concurrently": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/concurrently/-/concurrently-7.0.0.tgz",
-      "integrity": "sha512-pUOv0XBVexkfVOLWwzh8CMK7b+dnXGvq+/sJKfcws6b0vuMqNw8UeZUiaO9mWxfyS0eYGQyxg+J9EpVRxUCunA==",
-      "dev": true,
-      "requires": {
-        "concurrently": "*"
-      }
-    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -8509,15 +8478,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "@types/sass": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-      "dev": true,
-      "requires": {
-        "sass": "*"
-      }
     },
     "@types/send": {
       "version": "0.17.4",

--- a/package.json
+++ b/package.json
@@ -46,14 +46,12 @@
     "through2": "4.0.2"
   },
   "devDependencies": {
-    "@types/concurrently": "7.0.0",
     "@types/cors": "2.8.17",
     "@types/escape-html": "1.0.4",
     "@types/express": "4.17.21",
     "@types/jest": "29.5.12",
     "@types/node": "18.19.33",
     "@types/pug": "2.0.10",
-    "@types/sass": "1.45.0",
     "@types/showdown": "2.0.6",
     "@types/through2": "2.0.41",
     "cypress": "13.11.0",


### PR DESCRIPTION
`sass` and `concurrently` already provide their own type definitions, so there's no need anymore for external types

Fixes warnings:
> npm WARN deprecated @types/sass@1.45.0: This is a stub types definition. sass provides its own type definitions, so you do not need this installed.
npm WARN deprecated @types/concurrently@7.0.0: This is a stub types definition. concurrently provides its own type definitions, so you do not need this installed.